### PR TITLE
feat: Task Output Caching

### DIFF
--- a/src/TaskRunner.ts
+++ b/src/TaskRunner.ts
@@ -17,6 +17,8 @@ import { RetryingExecutionStrategy } from "./strategies/RetryingExecutionStrateg
 import { Plugin } from "./contracts/Plugin.js";
 import { PluginManager } from "./PluginManager.js";
 import { DryRunExecutionStrategy } from "./strategies/DryRunExecutionStrategy.js";
+import { CachingExecutionStrategy } from "./strategies/CachingExecutionStrategy.js";
+import { ICacheProvider } from "./contracts/ICacheProvider.js";
 
 const MERMAID_ID_REGEX = /[^a-zA-Z0-9_-]/g;
 
@@ -30,6 +32,7 @@ export class TaskRunner<TContext> {
   private readonly validator = new TaskGraphValidator();
   private executionStrategy: IExecutionStrategy<TContext> =
     new RetryingExecutionStrategy(new StandardExecutionStrategy());
+  private cacheProvider?: ICacheProvider;
 
   private readonly pluginManager: PluginManager<TContext>;
 
@@ -81,6 +84,16 @@ export class TaskRunner<TContext> {
    */
   public setExecutionStrategy(strategy: IExecutionStrategy<TContext>): this {
     this.executionStrategy = strategy;
+    return this;
+  }
+
+  /**
+   * Sets the cache provider to be used for task caching.
+   * @param cacheProvider The cache provider.
+   * @returns The TaskRunner instance for chaining.
+   */
+  public setCacheProvider(cacheProvider: ICacheProvider): this {
+    this.cacheProvider = cacheProvider;
     return this;
   }
 
@@ -197,6 +210,8 @@ export class TaskRunner<TContext> {
     let strategy = this.executionStrategy;
     if (config?.dryRun) {
       strategy = new DryRunExecutionStrategy<TContext>();
+    } else if (this.cacheProvider) {
+      strategy = new CachingExecutionStrategy(strategy, this.cacheProvider);
     }
 
     const executor = new WorkflowExecutor(

--- a/src/TaskStep.ts
+++ b/src/TaskStep.ts
@@ -15,6 +15,16 @@ export interface TaskStep<TContext> {
   retry?: TaskRetryConfig;
   /** Optional loop configuration for the task. */
   loop?: TaskLoopConfig<TContext>;
+
+  /** Optional caching configuration for the task. */
+  cache?: {
+    /** A function that returns a cache key based on the context. */
+    key: (context: TContext) => string | Promise<string>;
+    /** Optional time-to-live in milliseconds. Defaults to infinite if not provided. */
+    ttl?: number;
+    /** Optional function to re-apply side effects to the context from a cached result. */
+    restore?: (context: TContext, cachedResult: TaskResult) => void | Promise<void>;
+  };
   /**
    * Optional function to determine if the task should run.
    * If it returns false (synchronously or asynchronously), the task is skipped.

--- a/src/contracts/ICacheProvider.ts
+++ b/src/contracts/ICacheProvider.ts
@@ -1,0 +1,29 @@
+import { TaskResult } from "../TaskResult.js";
+
+/**
+ * Interface for cache providers used by the TaskRunner.
+ */
+export interface ICacheProvider {
+  /**
+   * Retrieves a cached result by its key.
+   * @param key The cache key.
+   * @returns A promise resolving to the cached TaskResult, or undefined if not found.
+   */
+  get(key: string): Promise<TaskResult | undefined>;
+
+  /**
+   * Stores a task result in the cache.
+   * @param key The cache key.
+   * @param result The TaskResult to store.
+   * @param ttl Optional time-to-live in milliseconds.
+   * @returns A promise resolving when the set operation completes.
+   */
+  set(key: string, result: TaskResult, ttl?: number): Promise<void>;
+
+  /**
+   * Removes a cached result by its key.
+   * @param key The cache key.
+   * @returns A promise resolving when the delete operation completes.
+   */
+  delete(key: string): Promise<void>;
+}

--- a/src/strategies/CachingExecutionStrategy.ts
+++ b/src/strategies/CachingExecutionStrategy.ts
@@ -1,0 +1,46 @@
+import { IExecutionStrategy } from "./IExecutionStrategy.js";
+import { TaskStep } from "../TaskStep.js";
+import { TaskResult } from "../TaskResult.js";
+import { ICacheProvider } from "../contracts/ICacheProvider.js";
+
+/**
+ * An execution strategy that wraps another strategy and adds caching capabilities.
+ */
+export class CachingExecutionStrategy<TContext> implements IExecutionStrategy<TContext> {
+  constructor(
+    private readonly innerStrategy: IExecutionStrategy<TContext>,
+    private readonly cacheProvider: ICacheProvider
+  ) {}
+
+  public async execute(
+    step: TaskStep<TContext>,
+    context: TContext,
+    signal?: AbortSignal
+  ): Promise<TaskResult> {
+    if (!step.cache) {
+      return this.innerStrategy.execute(step, context, signal);
+    }
+
+    const cacheKey = await step.cache.key(context);
+    const cachedResult = await this.cacheProvider.get(cacheKey);
+
+    if (cachedResult !== undefined) {
+      if (step.cache.restore) {
+        await step.cache.restore(context, cachedResult);
+      }
+
+      return {
+        ...cachedResult,
+        status: "skipped"
+      };
+    }
+
+    const result = await this.innerStrategy.execute(step, context, signal);
+
+    if (result.status === "success") {
+      await this.cacheProvider.set(cacheKey, result, step.cache.ttl);
+    }
+
+    return result;
+  }
+}

--- a/src/utils/MemoryCacheProvider.ts
+++ b/src/utils/MemoryCacheProvider.ts
@@ -1,0 +1,56 @@
+import { ICacheProvider } from "../contracts/ICacheProvider.js";
+import { TaskResult } from "../TaskResult.js";
+
+interface CacheEntry {
+  result: TaskResult;
+  expiresAt?: number;
+}
+
+/**
+ * A default, in-memory implementation of ICacheProvider.
+ */
+export class MemoryCacheProvider implements ICacheProvider {
+  private readonly cache = new Map<string, CacheEntry>();
+
+  /**
+   * Retrieves a cached result if it exists and has not expired.
+   */
+  public async get(key: string): Promise<TaskResult | undefined> {
+    const entry = this.cache.get(key);
+
+    if (!entry) {
+      return undefined;
+    }
+
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    // Return a clone of the cached result
+    return { ...entry.result };
+  }
+
+  /**
+   * Stores a result in the cache with an optional TTL.
+   */
+  public async set(key: string, result: TaskResult, ttl?: number): Promise<void> {
+    const entry: CacheEntry = {
+      // Store a clone of the result
+      result: { ...result }
+    };
+
+    if (ttl !== undefined && ttl > 0) {
+      entry.expiresAt = Date.now() + ttl;
+    }
+
+    this.cache.set(key, entry);
+  }
+
+  /**
+   * Removes a result from the cache.
+   */
+  public async delete(key: string): Promise<void> {
+    this.cache.delete(key);
+  }
+}

--- a/tests/CachingExecutionStrategy.test.ts
+++ b/tests/CachingExecutionStrategy.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CachingExecutionStrategy } from "../src/strategies/CachingExecutionStrategy.js";
+import { IExecutionStrategy } from "../src/strategies/IExecutionStrategy.js";
+import { ICacheProvider } from "../src/contracts/ICacheProvider.js";
+import { TaskStep } from "../src/TaskStep.js";
+import { TaskResult } from "../src/TaskResult.js";
+
+describe("CachingExecutionStrategy", () => {
+  let innerStrategy: IExecutionStrategy<unknown>;
+  let cacheProvider: ICacheProvider;
+  let strategy: CachingExecutionStrategy<unknown>;
+  let context: unknown;
+
+  beforeEach(() => {
+    innerStrategy = {
+      execute: vi.fn(),
+    };
+    cacheProvider = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
+    strategy = new CachingExecutionStrategy(innerStrategy, cacheProvider);
+    context = {};
+  });
+
+  it("should execute inner strategy directly if step has no cache config", async () => {
+    const step: TaskStep<unknown> = {
+      name: "task1",
+      run: vi.fn(),
+    };
+    const mockResult: TaskResult = { status: "success" };
+    vi.mocked(innerStrategy.execute).mockResolvedValue(mockResult);
+
+    const result = await strategy.execute(step, context);
+
+    expect(result).toBe(mockResult);
+    expect(innerStrategy.execute).toHaveBeenCalledWith(step, context, undefined);
+    expect(cacheProvider.get).not.toHaveBeenCalled();
+    expect(cacheProvider.set).not.toHaveBeenCalled();
+  });
+
+  it("should return cached result and status skipped on cache hit", async () => {
+    const step: TaskStep<unknown> = {
+      name: "task1",
+      cache: {
+        key: () => "my-key",
+      },
+      run: vi.fn(),
+    };
+    const cachedResult: TaskResult = { status: "success", data: "cached" };
+    vi.mocked(cacheProvider.get).mockResolvedValue(cachedResult);
+
+    const result = await strategy.execute(step, context);
+
+    expect(cacheProvider.get).toHaveBeenCalledWith("my-key");
+    expect(innerStrategy.execute).not.toHaveBeenCalled();
+    expect(result).toEqual({ ...cachedResult, status: "skipped" });
+  });
+
+  it("should execute restore function on cache hit if provided", async () => {
+    const restoreFn = vi.fn();
+    const step: TaskStep<unknown> = {
+      name: "task1",
+      cache: {
+        key: () => "my-key",
+        restore: restoreFn,
+      },
+      run: vi.fn(),
+    };
+    const cachedResult: TaskResult = { status: "success", data: "cached" };
+    vi.mocked(cacheProvider.get).mockResolvedValue(cachedResult);
+
+    const result = await strategy.execute(step, context);
+
+    expect(restoreFn).toHaveBeenCalledWith(context, cachedResult);
+    expect(result).toEqual({ ...cachedResult, status: "skipped" });
+  });
+
+  it("should execute inner strategy and store result on cache miss", async () => {
+    const step: TaskStep<unknown> = {
+      name: "task1",
+      cache: {
+        key: () => "my-key",
+        ttl: 1000,
+      },
+      run: vi.fn(),
+    };
+    const mockResult: TaskResult = { status: "success", data: "fresh" };
+    vi.mocked(cacheProvider.get).mockResolvedValue(undefined);
+    vi.mocked(innerStrategy.execute).mockResolvedValue(mockResult);
+
+    const result = await strategy.execute(step, context);
+
+    expect(cacheProvider.get).toHaveBeenCalledWith("my-key");
+    expect(innerStrategy.execute).toHaveBeenCalledWith(step, context, undefined);
+    expect(cacheProvider.set).toHaveBeenCalledWith("my-key", mockResult, 1000);
+    expect(result).toBe(mockResult);
+  });
+
+  it("should not store result if execution fails", async () => {
+    const step: TaskStep<unknown> = {
+      name: "task1",
+      cache: {
+        key: () => "my-key",
+      },
+      run: vi.fn(),
+    };
+    const mockResult: TaskResult = { status: "failure", error: "failed" };
+    vi.mocked(cacheProvider.get).mockResolvedValue(undefined);
+    vi.mocked(innerStrategy.execute).mockResolvedValue(mockResult);
+
+    const result = await strategy.execute(step, context);
+
+    expect(cacheProvider.set).not.toHaveBeenCalled();
+    expect(result).toBe(mockResult);
+  });
+});

--- a/tests/MemoryCacheProvider.test.ts
+++ b/tests/MemoryCacheProvider.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryCacheProvider } from "../src/utils/MemoryCacheProvider.js";
+import { TaskResult } from "../src/TaskResult.js";
+
+describe("MemoryCacheProvider", () => {
+  let cacheProvider: MemoryCacheProvider;
+
+  beforeEach(() => {
+    cacheProvider = new MemoryCacheProvider();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return undefined for a non-existent key", async () => {
+    const result = await cacheProvider.get("non-existent");
+    expect(result).toBeUndefined();
+  });
+
+  it("should store and retrieve a cached result", async () => {
+    const mockResult: TaskResult = { status: "success", data: "test" };
+    await cacheProvider.set("key1", mockResult);
+
+    const result = await cacheProvider.get("key1");
+    expect(result).toEqual(mockResult);
+    expect(result).not.toBe(mockResult); // Should be a clone
+  });
+
+  it("should respect ttl and expire results", async () => {
+    const mockResult: TaskResult = { status: "success" };
+    await cacheProvider.set("key2", mockResult, 1000); // 1 second TTL
+
+    let result = await cacheProvider.get("key2");
+    expect(result).toEqual(mockResult);
+
+    vi.advanceTimersByTime(1500);
+
+    result = await cacheProvider.get("key2");
+    expect(result).toBeUndefined();
+  });
+
+  it("should not expire results if ttl is not provided", async () => {
+    const mockResult: TaskResult = { status: "success" };
+    await cacheProvider.set("key3", mockResult);
+
+    vi.advanceTimersByTime(100000); // Advance by a long time
+
+    const result = await cacheProvider.get("key3");
+    expect(result).toEqual(mockResult);
+  });
+
+  it("should delete a cached result", async () => {
+    const mockResult: TaskResult = { status: "success" };
+    await cacheProvider.set("key4", mockResult);
+
+    await cacheProvider.delete("key4");
+
+    const result = await cacheProvider.get("key4");
+    expect(result).toBeUndefined();
+  });
+});

--- a/tests/TaskRunnerCaching.test.ts
+++ b/tests/TaskRunnerCaching.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { TaskRunner } from "../src/TaskRunner.js";
+import { MemoryCacheProvider } from "../src/utils/MemoryCacheProvider.js";
+import { TaskStep } from "../src/TaskStep.js";
+
+describe("TaskRunner Caching Integration", () => {
+  it("should cache task execution and skip on subsequent runs", async () => {
+    interface TestContext {
+      runCount: number;
+      restoredValue?: string;
+    }
+
+    const context: TestContext = { runCount: 0 };
+    const runner = new TaskRunner<TestContext>(context);
+    const cacheProvider = new MemoryCacheProvider();
+
+    runner.setCacheProvider(cacheProvider);
+
+    const task: TaskStep<TestContext> = {
+      name: "cached-task",
+      cache: {
+        key: () => "my-static-key",
+        restore: (ctx, result) => {
+          ctx.restoredValue = result.data as string;
+        }
+      },
+      run: async (ctx) => {
+        ctx.runCount++;
+        return { status: "success", data: "computation-result" };
+      }
+    };
+
+    // First run - cache miss
+    const result1 = await runner.execute([task]);
+    expect(result1.get("cached-task")?.status).toBe("success");
+    expect(context.runCount).toBe(1);
+
+    // Second run - cache hit
+    const result2 = await runner.execute([task]);
+    expect(result2.get("cached-task")?.status).toBe("skipped"); // Using skipped as requested
+    expect(context.runCount).toBe(1); // Run count shouldn't increase
+    expect(context.restoredValue).toBe("computation-result"); // Side effects should be restored
+  });
+});


### PR DESCRIPTION
Implemented task output caching.
Added `ICacheProvider` and `MemoryCacheProvider`.
Updated `TaskStep` with `cache` config.
Created `CachingExecutionStrategy` to wrap other strategies.
Updated `TaskRunner` with `setCacheProvider`.
Added tests.

---
*PR created automatically by Jules for task [2064568077896787681](https://jules.google.com/task/2064568077896787681) started by @thalesraymond*