### PR TITLE
Sanitize brackets and parentheses in Mermaid generation

### DIFF
--- a/src/TaskRunner.ts
+++ b/src/TaskRunner.ts
@@ -137,7 +137,14 @@ export class TaskRunner<TContext> {
       processedNodes.add(stepId);
 
       if (processedNodes.size !== sizeBefore) {
-        const escapedName = name.replaceAll("\"", "&quot;");
+        const escapedName = name
+          .replaceAll("\"", "&quot;")
+          .replaceAll("[", "&#91;")
+          .replaceAll("]", "&#93;")
+          .replaceAll("(", "&#40;")
+          .replaceAll(")", "&#41;")
+          .replaceAll("{", "&#123;")
+          .replaceAll("}", "&#125;");
         nodeLines.push(`  ${stepId}["${escapedName}"]`);
       }
 

--- a/tests/TaskRunnerMermaid.test.ts
+++ b/tests/TaskRunnerMermaid.test.ts
@@ -95,9 +95,9 @@ describe("TaskRunner Mermaid Graph", () => {
     const graph = TaskRunner.getMermaidGraph(steps);
     const lines = graph.split("\n");
 
-    // Current implementation fails to sanitize these, leading to invalid Mermaid syntax
-    // e.g., Task[1]["Task[1]"] which is confusing/invalid
-    expect(lines).toContain("  Task_3_[\"Task{3}\"]");
+    expect(lines).toContain("  Task_1_[\"Task&#91;1&#93;\"]");
+    expect(lines).toContain("  Task_2_[\"Task&#40;2&#41;\"]");
+    expect(lines).toContain("  Task_3_[\"Task&#123;3&#125;\"]");
   });
 
   it("should handle ID collisions by appending a counter", () => {


### PR DESCRIPTION
This PR fixes an issue where special characters like brackets and parentheses in task names would lead to invalid Mermaid syntax in the generated graph.

Changes:
- Modified `src/TaskRunner.ts`: Added `.replaceAll()` calls to escape `[`, `]`, `(`, `)`, `{`, and `}` with their HTML entity equivalents (`&#91;`, `&#93;`, etc.) in the node label generation logic.
- Modified `tests/TaskRunnerMermaid.test.ts`: Updated the "should sanitize brackets and parentheses" test case to expect the HTML entities.

Verification:
- Ran `pnpm test` and all 168 tests passed.
- Coverage remains at 100%.

---
*PR created automatically by Jules for task [15954113916093178468](https://jules.google.com/task/15954113916093178468) started by @thalesraymond*