### PR TITLE
test: improve mutation testing coverage across core modules

### DIFF
--- a/ts/tests/PluginManager_mutants.test.ts
+++ b/ts/tests/PluginManager_mutants.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { PluginManager } from "../src/PluginManager.js";
 import { Plugin } from "../src/contracts/Plugin.js";
 import { EventBus } from "../src/EventBus.js";
@@ -64,5 +64,103 @@ describe("PluginManager Mutants", () => {
 
     expect(asyncCalled).toBe(true);
     expect(syncCalled).toBe(true);
+  });
+
+  it("should handle purely synchronous plugins correctly without instantiating promises array", async () => {
+    const eventBus = new EventBus<void>();
+    const context = {
+      sharedContext: undefined as unknown as void,
+      eventBus,
+      stateManager: {} as unknown,
+      executor: {} as unknown
+    } as unknown as unknown;
+
+    /* @ts-expect-error Bypass */
+    const manager = new PluginManager<void>(context);
+
+    const syncPlugin: Plugin<void> = {
+      name: "sync-plugin-2",
+      version: "1.0",
+      install: () => {
+        return undefined; // Not a promise
+      }
+    };
+
+    manager.use(syncPlugin);
+
+    const promiseAllSpy = vi.spyOn(Promise, "all");
+
+    await manager.initialize();
+
+    // Promise.all should NOT be called at all if there are only sync plugins
+    // because `installPromises` will remain undefined.
+    // This kills the mutant replacing `if (result instanceof Promise)` with `if (true)`.
+    expect(promiseAllSpy).not.toHaveBeenCalled();
+    promiseAllSpy.mockRestore();
+  });
+
+  it("should initialize installPromises array properly without mutating array content", async () => {
+    const eventBus = new EventBus<void>();
+    const context = {
+      sharedContext: undefined as unknown as void,
+      eventBus,
+      stateManager: {} as unknown,
+      executor: {} as unknown
+    } as unknown as unknown;
+
+    /* @ts-expect-error Bypass */
+    const manager = new PluginManager<void>(context);
+
+    const asyncPlugin: Plugin<void> = {
+      name: "async-plugin-3",
+      version: "1.0",
+      install: async () => {
+        return Promise.resolve();
+      }
+    };
+
+    manager.use(asyncPlugin);
+
+    const promiseAllSpy = vi.spyOn(Promise, "all");
+
+    await manager.initialize();
+
+    // If installPromises was initialized as ["Stryker was here"], Promise.all would have
+    // been called with ["Stryker was here", Promise].
+    // We check that it was called with exactly an array containing one Promise.
+    expect(promiseAllSpy).toHaveBeenCalledTimes(1);
+    const args = promiseAllSpy.mock.calls[0][0];
+    expect(Array.isArray(args)).toBe(true);
+    expect(args).toHaveLength(1);
+    expect(args[0]).toBeInstanceOf(Promise);
+
+    promiseAllSpy.mockRestore();
+  });
+
+  it("should only initialize installPromises once for multiple async plugins", async () => {
+    const eventBus = new EventBus<void>();
+    const context = {
+      sharedContext: undefined as unknown as void,
+      eventBus,
+      stateManager: {} as unknown,
+      executor: {} as unknown
+    } as unknown as unknown;
+
+    /* @ts-expect-error Bypass */
+    const manager = new PluginManager<void>(context);
+
+    manager.use({ name: "p1", version: "1", install: async () => {} });
+    manager.use({ name: "p2", version: "1", install: async () => {} });
+
+    // If `if (!installPromises)` is replaced with `if (true)`, it reinitializes `installPromises = []`
+    // on the second plugin, losing the first plugin's promise.
+    const promiseAllSpy = vi.spyOn(Promise, "all");
+    await manager.initialize();
+
+    expect(promiseAllSpy).toHaveBeenCalledTimes(1);
+    const args = promiseAllSpy.mock.calls[0][0];
+    expect(args).toHaveLength(2); // Should have both promises
+
+    promiseAllSpy.mockRestore();
   });
 });

--- a/ts/tests/TaskGraphValidator_mutants.test.ts
+++ b/ts/tests/TaskGraphValidator_mutants.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { TaskGraphValidator } from "../src/TaskGraphValidator.js";
 import { ERROR_CYCLE, ERROR_DUPLICATE_TASK } from "../src/contracts/ErrorTypes.js";
 import { TaskGraph } from "../src/TaskGraph.js";
@@ -59,5 +59,45 @@ describe("TaskGraphValidator Mutants", () => {
       };
       const result = validator.validate(graph);
       expect((result.errors[0].details as { cyclePath: string[] }).cyclePath).toEqual(["B", "C", "B"]);
+  });
+
+  it("should skip already visited tasks in cycle detection without executing the block", () => {
+      const validator = new TaskGraphValidator();
+      const graph: TaskGraph = {
+          tasks: [
+              { id: "A", dependencies: ["B"] },
+              { id: "B", dependencies: [] },
+              { id: "C", dependencies: [] }
+          ]
+      };
+
+      // @ts-expect-error bypass private access
+      const detectCycleSpy = vi.spyOn(validator, "detectCycle");
+
+      const result = validator.validate(graph);
+
+      expect(result.isValid).toBe(true);
+      // "A" visits "B". Then the outer loop encounters "B", it should hit the continue block
+      // and NOT call detectCycle again. "C" is then visited and calls detectCycle.
+      // So detectCycle should be called for "A" and "C" only.
+      expect(detectCycleSpy).toHaveBeenCalledTimes(2);
+      expect(detectCycleSpy).not.toHaveBeenCalledWith(
+        "B", expect.anything(), expect.anything(), expect.anything(), expect.anything()
+      );
+  });
+
+  it("should initialize path as empty array instead of mutated value", () => {
+      const validator = new TaskGraphValidator();
+      const graph: TaskGraph = {
+          tasks: [
+              { id: "A", dependencies: ["A"] } // cycle to itself
+          ]
+      };
+      const result = validator.validate(graph);
+      // If path was initialized as ["Stryker was here"], cyclePath would be ["Stryker was here", "A", "A"]
+      // or similar instead of ["A", "A"]
+      expect((result.errors[0].details as { cyclePath: string[] }).cyclePath).toEqual(["A", "A"]);
+      // Also check the error message starts properly
+      expect(result.errors[0].message).toBe("Cycle detected: A -> A");
   });
 });

--- a/ts/tests/TaskStateManager_mutants2.test.ts
+++ b/ts/tests/TaskStateManager_mutants2.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { TaskStateManager } from "../src/TaskStateManager.js";
+import { EventBus } from "../src/EventBus.js";
+import { TaskStep } from "../src/TaskStep.js";
+
+describe("TaskStateManager cascaded failure mutants", () => {
+    it("should format depError without error message if error is missing when cascading failure", () => {
+        const eventBus = new EventBus<void>();
+        const stateManager = new TaskStateManager<void>(eventBus);
+
+        const step1: TaskStep<void> = { name: "Step1", run: async () => ({ status: "failure" }) };
+        const step2: TaskStep<void> = { name: "Step2", run: async () => ({ status: "success" }), dependencies: ["Step1"] };
+
+        stateManager.initialize([step1, step2]);
+        const ready = stateManager.processDependencies();
+
+        // This will trigger cascadeFailure inside markCompleted
+        stateManager.markCompleted(ready[0], { status: "failure" }); // No error string
+
+        const results = stateManager.getResults();
+        expect(results.get("Step2")?.status).toBe("skipped");
+        expect(results.get("Step2")?.message).toBe("Skipped because dependency 'Step1' failed");
+    });
+
+    it("should format depError with error message if available when cascading failure", () => {
+        const eventBus = new EventBus<void>();
+        const stateManager = new TaskStateManager<void>(eventBus);
+
+        const step1: TaskStep<void> = { name: "Step1", run: async () => ({ status: "failure" }) };
+        const step2: TaskStep<void> = { name: "Step2", run: async () => ({ status: "success" }), dependencies: ["Step1"] };
+
+        stateManager.initialize([step1, step2]);
+        const ready = stateManager.processDependencies();
+
+        stateManager.markCompleted(ready[0], { status: "failure", error: "Boom" });
+
+        const results = stateManager.getResults();
+        expect(results.get("Step2")?.status).toBe("skipped");
+        expect(results.get("Step2")?.message).toBe("Skipped because dependency 'Step1' failed: Boom");
+    });
+
+    it("should not crash if currentResult is undefined in cascadeFailure", () => {
+        const eventBus = new EventBus<void>();
+        const stateManager = new TaskStateManager<void>(eventBus);
+
+        const step1: TaskStep<void> = { name: "Step1", run: async () => ({ status: "failure" }) };
+        const step2: TaskStep<void> = { name: "Step2", run: async () => ({ status: "success" }), dependencies: ["Step1"] };
+
+        stateManager.initialize([step1, step2]);
+
+        // @ts-expect-error bypass private access to call cascadeFailure manually without currentResult
+        stateManager.cascadeFailure("Step1");
+
+        const results = stateManager.getResults();
+        expect(results.get("Step2")?.status).toBe("skipped");
+        expect(results.get("Step2")?.message).toBe("Skipped because dependency 'Step1' failed");
+    });
+
+    it("should break out of while loop when head reaches queue length", () => {
+        const eventBus = new EventBus<void>();
+        const stateManager = new TaskStateManager<void>(eventBus);
+        const step1: TaskStep<void> = { name: "Step1", run: async () => ({ status: "failure" }) };
+        const step2: TaskStep<void> = { name: "Step2", run: async () => ({ status: "success" }), dependencies: ["Step1"] };
+        stateManager.initialize([step1, step2]);
+
+        const ready = stateManager.processDependencies();
+        // Since dependencyGraph is initialized inside TaskStateManager, let's just spy on map.get
+        // @ts-expect-error bypass private access
+        const mapGetSpy = vi.spyOn(stateManager.dependencyGraph, "get");
+
+        stateManager.markCompleted(ready[0], { status: "failure" });
+
+        // If while loop had `head <= queue.length`, it would do map.get(undefined)
+        expect(mapGetSpy).not.toHaveBeenCalledWith(undefined);
+    });
+});

--- a/ts/tests/utils_mutants.test.ts
+++ b/ts/tests/utils_mutants.test.ts
@@ -76,6 +76,86 @@ describe("PriorityQueue Mutants", () => {
       queue.push("D", 2);
       expect(queue.pop()).toBe("A");
   });
+
+  it("should handle compare exact equality gracefully", () => {
+    // Since sequence IDs are unique per push, compare() NEVER returns exactly 0
+    // for two different elements. To kill `>= 0` vs `> 0` mutant, we must force it.
+    // We can do this by using the internal method if possible, or by mocking sequenceId
+    // or we can test true/false by bypassing visibility checks to push duplicate sequenceIds
+    const queue = new PriorityQueue<number>();
+    // @ts-expect-error Accessing private property to force same sequenceId
+    queue.sequenceCounter = 1;
+    queue.push(10, 10); // root (seq 1) -> popped
+    // @ts-expect-error Accessing private property
+    queue.sequenceCounter = 1;
+    queue.push(2, 2);   // left child (seq 1)
+    // @ts-expect-error Accessing private property
+    queue.sequenceCounter = 1;
+    queue.push(5, 5);   // right child (seq 1)
+    // @ts-expect-error Accessing private property
+    queue.sequenceCounter = 1;
+    queue.push(5, 5);   // next root (seq 1)
+
+    // After pop:
+    // root is D(5, seq1)
+    // left is B(2, seq1) -> compare(B, D) = 2-5 = -3 < 0. swapIndex = null
+    // right is C(5, seq1) -> compare(C, D) = 5-5 = 0. seq1-seq1 = 0.
+    // If we use >= 0, swapIndex becomes rightChild (2).
+    // If > 0, swapIndex remains null.
+    // So if >= 0, root swaps with right child.
+    // Meaning C becomes root, D becomes right child.
+    // Pop again: if it swapped, we pop C. If not, we pop D.
+    // Wait, C and D are both 5.
+    // Let's use different items to distinguish:
+
+    const queue2 = new PriorityQueue<string>();
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 1;
+    queue2.push("A", 10);
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 1;
+    queue2.push("B", 2); // left
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 1;
+    queue2.push("C", 5); // right
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 1;
+    queue2.push("D", 5); // next root
+
+    queue2.pop(); // pops A, D becomes root
+    // D is root. left is B, right is C.
+    // B vs D: B(2) < D(5) -> swapIndex = null
+    // C vs D: C(5) == D(5), seq == seq -> compare = 0.
+    // If > 0: no swap. D is root. Next pop returns D.
+    // If >= 0: swap with C. C is root. Next pop returns C.
+    expect(queue2.pop()).toBe("D");
+  });
+
+  it("should handle compare exact equality when swapIndex !== null", () => {
+    const queue2 = new PriorityQueue<string>();
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 1;
+    queue2.push("A", 10);
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 1;
+    queue2.push("B", 5); // left
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 1;
+    queue2.push("C", 5); // right
+    // @ts-expect-error Bypass
+    queue2.sequenceCounter = 2; // D seq=2, so B>D and C>D
+    queue2.push("D", 2); // next root
+
+    queue2.pop(); // pops A, D becomes root
+    // D(2, seq2) is root. left is B(5, seq1), right is C(5, seq1).
+    // B vs D: B(5) > D(2) -> swapIndex = leftChild (1)
+    // C vs B: C(5) == B(5), seq1 == seq1 -> compare = 0.
+    // If swapIndex !== null && compare(right, left) >= 0: swapIndex becomes rightChild (2).
+    // If > 0: swapIndex remains leftChild (1).
+    // So if >= 0, C becomes root. Next pop is C.
+    // If > 0, B becomes root. Next pop is B.
+    expect(queue2.pop()).toBe("B");
+  });
 });
 
 describe("sleep Mutants", () => {


### PR DESCRIPTION
Resolved 5 mutation testing survivals. Added test cases to kill:
- `PriorityQueue.ts` conditional `(swapIndex === null && this.compare(...) >= 0)` mutant
- `TaskGraphValidator.ts` `continue` replacing block mutant inside duplicate validation
- `PluginManager.ts` `if (result instanceof Promise)` mutating conditionals
- `TaskStateManager.ts` `error` mapping and iteration loop edge mutants.

Tests effectively employ targeted spies and visibility bypasses to handle strict logical conditions.

---
*PR created automatically by Jules for task [14347855601395614236](https://jules.google.com/task/14347855601395614236) started by @thalesraymond*