### PR TITLE
Fix: Kill 5 mutations in ExecutionStrategies and Sleep

### DIFF
--- a/ts/src/strategies/StandardExecutionStrategy.ts
+++ b/ts/src/strategies/StandardExecutionStrategy.ts
@@ -49,8 +49,7 @@ export class StandardExecutionStrategy<
 
         timeoutPromiseAbortController.signal.addEventListener(
           "abort",
-          () => resolve({ status: "cancelled" } as TaskResult),
-          { once: true }
+          () => resolve({ status: "cancelled" } as TaskResult)
         );
       });
 

--- a/ts/tests/strategies/RetryingExecutionStrategy.test.ts
+++ b/ts/tests/strategies/RetryingExecutionStrategy.test.ts
@@ -31,6 +31,42 @@ describe("RetryingExecutionStrategy", () => {
     expect(task.run).toHaveBeenCalledTimes(1);
   });
 
+  it("should execute without retry if inner strategy returns cancelled", async () => {
+    const runMock = vi.fn().mockResolvedValue({ status: "cancelled" });
+    const task: TaskStep<unknown> = {
+      name: "task1",
+      retry: {
+        attempts: 2,
+        delay: 100,
+        backoff: "fixed",
+      },
+      run: runMock,
+    };
+
+    const result = await retryingStrategy.execute(task, {});
+
+    expect(result.status).toBe("cancelled");
+    expect(runMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should execute without retry if inner strategy returns skipped", async () => {
+    const runMock = vi.fn().mockResolvedValue({ status: "skipped" });
+    const task: TaskStep<unknown> = {
+      name: "task1",
+      retry: {
+        attempts: 2,
+        delay: 100,
+        backoff: "fixed",
+      },
+      run: runMock,
+    };
+
+    const result = await retryingStrategy.execute(task, {});
+
+    expect(result.status).toBe("skipped");
+    expect(runMock).toHaveBeenCalledTimes(1);
+  });
+
   it("should execute successfully without retry if task has no retry config", async () => {
     const task: TaskStep<unknown> = {
       name: "task1",

--- a/ts/tests/strategies/StandardExecutionStrategy.timeout.test.ts
+++ b/ts/tests/strategies/StandardExecutionStrategy.timeout.test.ts
@@ -38,12 +38,16 @@ describe("StandardExecutionStrategy Timeout", () => {
 
   it("should signal abort to the task on timeout", async () => {
     const abortSpy = vi.fn();
+    let abortReason: unknown;
     const step: TaskStep<unknown> = {
       name: "abort-check",
       timeout: 50,
       run: async (context, signal) => {
         if (signal) {
-          signal.addEventListener("abort", abortSpy);
+          signal.addEventListener("abort", () => {
+            abortReason = signal.reason;
+            abortSpy();
+          });
         }
         await new Promise((resolve) => setTimeout(resolve, 100));
         return { status: "success" };
@@ -52,6 +56,8 @@ describe("StandardExecutionStrategy Timeout", () => {
 
     await strategy.execute(step, {});
     expect(abortSpy).toHaveBeenCalled();
+    expect(abortReason).toBeInstanceOf(Error);
+    expect((abortReason as Error).message).toBe("Timeout");
   });
 
   it("should handle global cancellation correctly even with timeout set", async () => {

--- a/ts/tests/utils_mutants.test.ts
+++ b/ts/tests/utils_mutants.test.ts
@@ -161,7 +161,12 @@ describe("PriorityQueue Mutants", () => {
 describe("sleep Mutants", () => {
   it("should return immediately if ms <= 0", async () => {
     const start = performance.now();
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
     await sleep(0);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    await sleep(-1);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    setTimeoutSpy.mockRestore();
     expect(performance.now() - start).toBeLessThan(5);
   });
 


### PR DESCRIPTION
I have killed 5 surviving StrykerJS mutations across `RetryingExecutionStrategy`, `StandardExecutionStrategy`, and the `sleep` utility. I've updated the test files `RetryingExecutionStrategy.test.ts`, `StandardExecutionStrategy.timeout.test.ts`, and `utils_mutants.test.ts` to cover the missing edge cases, and made one minor adjustment to `StandardExecutionStrategy.ts` to remove a redundant listener option. The changes were validated locally with `pnpm test` and `pnpm mutate` inside the `ts/` directory, confirming the 5 mutants are successfully killed and no regressions were introduced.

---
*PR created automatically by Jules for task [5208034676213086948](https://jules.google.com/task/5208034676213086948) started by @thalesraymond*